### PR TITLE
Fix Mobile Hero Banner

### DIFF
--- a/src/components/Series/HeroBanner.tsx
+++ b/src/components/Series/HeroBanner.tsx
@@ -69,7 +69,7 @@ const HeroBanner: React.FC<Props> = ({ teams, members }) => {
         </Grid>
       )}
       <Grid container item xs={12} md={8}>
-        {shuffledMembers.slice(mobile ? -4 : 4, 10).map((shuffledMember) => (
+        {shuffledMembers.slice(mobile ? -4 : -6).map((shuffledMember) => (
           <Grid
             container
             item


### PR DESCRIPTION
Second row of shuffled heroes was not displaying on mobile, so I fixed the logic.