### PR TITLE
Remove Mobile Highlight tap color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: transparent;
 }
 
 code {


### PR DESCRIPTION
On mobile when you tap a hero or team, there is a blue highlight. Due to the interactivity of the website, it can be quite bothersome to keep having blue flashes. 